### PR TITLE
Feature: Renumber

### DIFF
--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -462,9 +462,8 @@ buffer if only the active region is renumbered."
 	current-line-number)
     (save-excursion
       (goto-char point-start)
-      (while (and (not (eobp))
-		  (<= (point) point-end))
-	(unless (looking-at "^$")
+      (while (not (eobp))
+	(unless (looking-at "^[ \t]*$")
 	  (setq current-line-number (string-to-number (basic-remove-line-number)))
 	  (let ((jump-locations (gethash current-line-number jump-list)))
 	    (save-excursion
@@ -477,8 +476,7 @@ buffer if only the active region is renumbered."
 	  (beginning-of-line)
 	  (insert (basic-format-line-number new-line-number))
 	  (setq new-line-number (+ new-line-number increment)))
-	(forward-line 1)
-	(end-of-line)))
+	(forward-line 1)))
     (maphash (lambda (target sources)
 	       (dolist (m sources)
 		 (when (marker-position m)

--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -446,7 +446,7 @@ buffer if only the active region is renumbered."
 				      (or (basic-current-line-number)
 					  basic-renumber-increment))))
 		      (string-to-number (read-string
-					 (format "Starting with (default %d): "
+					 (format "Renumber, starting with (default %d): "
 						 default)
 					 nil nil
 					 (int-to-string default))))

--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -472,7 +472,8 @@ have numbers are included in the renumbering.
 	(point-end (if (use-region-p) (region-end) (point-max))))
     (save-excursion
       (goto-char point-start)
-      (while (not (eobp))
+      (while (and (not (eobp))
+		  (< (point) point-end))
 	(unless (looking-at "^[ \t]*$")
 	  (let ((current-line-number (string-to-number (basic-remove-line-number))))
 	    (when (or basic-renumber-unnumbered-lines

--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -413,8 +413,8 @@ in the beginning of the line."
   (let ((jump-targets (make-hash-table)))
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward "go\\(sub\\|to\\)[ \t]*\\([0-9]+\\)" nil t)
-	(let ((target (string-to-number (match-string-no-properties 2))))
+      (while (re-search-forward "\\(go\\(sub\\|to\\)\\|then\\)[ \t]*\\([0-9]+\\)" nil t)
+	(let ((target (string-to-number (match-string-no-properties 3))))
 	  (unless (gethash target jump-targets)
 	    (puthash target nil jump-targets))
 	  (push (point-marker) (gethash target jump-targets)))))

--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -493,6 +493,7 @@ buffer if only the active region is renumbered."
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-f" 'basic-format-code)
     (define-key map "\r" 'basic-newline-and-number)
+    (define-key map "\C-c\C-r" 'basic-renumber)
     map)
   "Keymap used in ‘basic-mode'.")
 


### PR DESCRIPTION
Hm.  Maybe it's not a problem creating a new PR anyway. Just be aware that the first couple of commits here are the subject of PR#4, which needs to be committed first. (well, it's mostly independent features, but both use the new function basic-current-line-number, which was introduced in PR#4.)

Anyway, here it is, the renumbering feature.  Works by two passes - the first scans the whole buffer for jumps, and puts markers on them, associated with the target line numbers.  The second pass does the renumbering, and checks if the line being renumbered was the target of any jumps.  In that case, the list of markers for that target is traversed and updated.

The only need I have for Basic is for nostalgia, playing with Commodore 64 emulation in Vice.  The basic version in C64 does not have the "on x goto a,b,c" construct.  In fact I was not aware of such a construct until earlier today.  Consequently, the first iteration of this feature does not support those jump constructs.

I believe the basic algorithm I described above is still applicable for on.. jumps, but the scanning pass needs a smarter parser to deal with lists of numbers after goto/gosub, and placing markers after each number.