### PR TITLE
Fix indentation when decrease keyword is not at bol

### DIFF
--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -157,7 +157,7 @@ end of a line.")
               'symbols)
   "Regexp string of keywords that decrease indentation.
 These keywords decrease indentation when found at the
-beginning of a line.")
+beginning of a line or after a statement separator (:).")
 
 (defconst basic-comment-and-string-faces
   '(font-lock-comment-face font-lock-comment-delimiter-face font-lock-string-face)
@@ -285,11 +285,18 @@ while other keywords do it when found at the beginning of a line."
 (defun basic-decrease-indent-p ()
   "Return non-nil if indentation should be decreased.
 Some keywords trigger un-indentation when found at the beginning
-of a line, see `basic-decrease-indent-keywords-bol'."
+of a line or statement, see `basic-decrease-indent-keywords-bol'."
   (save-excursion
     (beginning-of-line)
     (re-search-forward "[^0-9 \t\n]" (point-at-eol) t)
-    (basic-match-symbol-at-point-p basic-decrease-indent-keywords-bol)))
+    (or (basic-match-symbol-at-point-p basic-decrease-indent-keywords-bol)
+	(let ((match nil))
+	  (basic-code-search-backward)
+	  (beginning-of-line)
+	  (while (and (not match)
+		      (re-search-forward ":[ \t\n]*" (point-at-eol) t))
+	    (setq match (basic-match-symbol-at-point-p basic-decrease-indent-keywords-bol)))
+	  match))))
 
 (defun basic-current-indent ()
   "Return the indent column of the current code line.


### PR DESCRIPTION
Basic has : as a statement separator.  The keywords in
basic-decrease-indent-keywords-bol should be considered when they come
directly after a colon as well as when they occur at the beginning of
line.

Delay loops are commonly written on one line in C64 basic:
  for x = 1 to delay: next x

It was annoying to have that construct increase the indentation of
subsequenct lines.