### PR TITLE
Fix tabification bug when indenting code with line numbers

### DIFF
--- a/src/basic-mode.el
+++ b/src/basic-mode.el
@@ -440,12 +440,22 @@ non-blank character after the line number."
   "Indent current line to COLUMN, also considering line numbers."
   ;; Remove line number
   (let* ((line-number (basic-remove-line-number))
-         (formatted-number (basic-format-line-number line-number)))
+         (formatted-number (basic-format-line-number line-number))
+	 (beg (point)))
     ;; Indent line
     (indent-line-to column)
     ;; Add line number again
+    (untabify beg (point))
     (beginning-of-line)
-    (insert formatted-number)))
+    ;; (setq beg (point))
+    (insert formatted-number)
+
+    ;; Note: re-tabifying doesn't make sense if after adding in the
+    ;; line number the indentation doesn't align with tabs.
+    ;;
+    ;;    (end-of-line)
+    ;;    (tabify beg (point))
+    ))
 
 (defun basic-electric-colon ()
   "Insert a colon and re-indent line."


### PR DESCRIPTION
Previously, `basic-indent-line-to` removed the line number and called `indent-line-to` which inserts tabs, presuming tab stops every tab-width spaces. Then it prepended the line number to the beginning, which had the side effect of changing how many spaces the first tab was equivalent to.

For example, presuming a tab-width of 8, then `(basic-indent-line-to 4)` uses four spaces, but `(basic-indent-line-to 8)` uses one tab. Since spaces are for relative positioning, while tabs provide (relatively) absolute positioning, prepending less than 8 characters of text would shift over the four spaces but not change the tab.

This patch fixes that by simply untabifying the result from `indent-line-to`; that is, all tabs are turned into the appropriate number of spaces so everything is using relative positioning.

ADDITIONAL DETAILS

A better fix might be to retabify the line after prepending the line number. After all, tabs can be useful and some programmers prefer them. However, after adding the code to do that, I realized there was a fundamental flaw: the benefits of tabs only make sense if they are actually used for tabulation. That is, the code has to align, at least partially, with the tab-width, which essentially means that basic-line-number-cols would be fixed at a multiple of tab-width.

Since alignment is unlikely to be the case, tabs would actually make navigation in Emacs more difficult. For example, imagine point is on column 14, at the start of a FOR statement and the next line is indented to column 18. Where does C-n (next line) go to? If tabs are used, the answer is 16, which is ridiculous and not helpful to anyone.

Trying to align the code with the tab-width -- or checking if it is -- doesn't seem worth it to me, so I left the re-tabification code commented out. At least for now. Feel free to delete it, if you wish.